### PR TITLE
Change constraint evaluation to no longer panic on inapplicability

### DIFF
--- a/core/src/main/java/at/sfischer/constraints/Constraint.java
+++ b/core/src/main/java/at/sfischer/constraints/Constraint.java
@@ -19,6 +19,7 @@ public record Constraint(Node term) {
     public <T> ConstraintResults applyData(DataCollection<T> data) {
         DataCollection<T> validConstraintData = data.clone();
         DataCollection<T> missingEvidenceConstraintData = data.emptyDataCollection();
+        DataCollection<T> inapplicableConstraintData = data.emptyDataCollection();
         AtomicBoolean evaluatedTrue = new AtomicBoolean(false);
 
         Set<String> variableNames = new HashSet<>();
@@ -37,8 +38,8 @@ public record Constraint(Node term) {
                     validConstraintData.removeDataEntry(dataObject);
                 }
             } else {
-                // TODO: Do not panic when a constraint does not apply for data, but instead store a counter for this and use it as an additional statistic to derive a likelihood for a constraint to be true.
-                throw new IllegalArgumentException("Could not apply data (" + values + ") to constraint, remaining: " + result.getClass().getName());
+                validConstraintData.removeDataEntry(dataObject);
+                inapplicableConstraintData.addDataEntry(dataObject);
             }
         });
 
@@ -47,6 +48,6 @@ public record Constraint(Node term) {
             validConstraintData.addAll(missingEvidenceConstraintData);
         }
 
-        return new ConstraintResults(this, data, validConstraintData);
+        return new ConstraintResults(this, data, validConstraintData, inapplicableConstraintData);
     }
 }

--- a/core/src/main/java/at/sfischer/constraints/ConstraintResults.java
+++ b/core/src/main/java/at/sfischer/constraints/ConstraintResults.java
@@ -7,14 +7,40 @@ import at.sfischer.constraints.data.DataCollection;
  * @param data                Data on which the constraint was evaluated on.
  * @param validConstraintData Data for which the constraint evaluates to true.
  */
-public record ConstraintResults(Constraint constraint, DataCollection<?> data, DataCollection<?> validConstraintData) {
+public record ConstraintResults(Constraint constraint, DataCollection<?> data, DataCollection<?> validConstraintData, DataCollection<?> inapplicableConstraintData) {
+    public ConstraintResults(Constraint constraint, DataCollection<?> data, DataCollection<?> validConstraintData) {
+        this(constraint, data, validConstraintData, data.emptyDataCollection());
+    }
+
+    public ConstraintResults(Constraint constraint, DataCollection<?> data, DataCollection<?> validConstraintData, DataCollection<?> inapplicableConstraintData) {
+        this.constraint = constraint;
+        this.data = data;
+        this.validConstraintData = validConstraintData;
+        this.inapplicableConstraintData = inapplicableConstraintData;
+    }
 
     public boolean foundCounterExample() {
         return numberOfViolations() > 0;
     }
 
     public int numberOfViolations() {
-        return data.numberOfDataEntries() - validConstraintData.numberOfDataEntries();
+        return data.numberOfDataEntries() - validConstraintData.numberOfDataEntries() - numberOfInapplicableEntries();
+    }
+
+    public int numberOfValidDataEntries(){
+        if(validConstraintData == null){
+            return 0;
+        }
+
+        return validConstraintData.numberOfDataEntries();
+    }
+
+    public int numberOfInapplicableEntries() {
+        if(inapplicableConstraintData == null){
+            return 0;
+        }
+
+        return inapplicableConstraintData.numberOfDataEntries();
     }
 
     public double applicationRate() {
@@ -31,6 +57,7 @@ public record ConstraintResults(Constraint constraint, DataCollection<?> data, D
                 "constraint=" + constraint +
                 ", data=" + data.size() +
                 ", validConstraintData=" + validConstraintData.size() +
+                ", inapplicableConstraintData=" + numberOfInapplicableEntries() +
                 '}';
     }
 }

--- a/core/src/test/java/at/sfischer/constraints/ConstraintTest.java
+++ b/core/src/test/java/at/sfischer/constraints/ConstraintTest.java
@@ -82,12 +82,12 @@ public class ConstraintTest {
 				"{size:3, isEmpty:false}"
 		);
 
-		Exception exception = assertThrows(IllegalArgumentException.class, () -> constraint.applyData(data));
+		ConstraintResults expected = new ConstraintResults(constraint, data, new SimpleDataCollection(), data);
+		ConstraintResults actual = constraint.applyData(data);
 
-		String expectedMessage = "Could not apply data ";
-		String actualMessage = exception.getMessage();
-
-		assertTrue(actualMessage.startsWith(expectedMessage));
+		assertThat(actual).
+				usingRecursiveComparison().
+				isEqualTo(expected);
 	}
 
 	@Test


### PR DESCRIPTION
Update constraint results to include data set of entires where data could not be applied (i.e. because the referred fields do not exist).